### PR TITLE
compatibility with SimpleTweaks' "Bait Command"

### DIFF
--- a/OceanFishin.cs
+++ b/OceanFishin.cs
@@ -36,7 +36,7 @@ namespace OceanFishin
         public string Name => "Ocean Fishin'";
 
         public const string CommandName = "/oceanfishing";
-        public const string AltCommandName = "/bait";
+        public const string AltCommandName = "/fishin";
 
         private DalamudPluginInterface PluginInterface { get; init; }
         private CommandManager CommandManager { get; init; }

--- a/OceanFishin.csproj
+++ b/OceanFishin.csproj
@@ -34,6 +34,10 @@
 		<DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+		   <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="DalamudPackager" Version="2.1.10" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is for development of the plugin! If you just want to use this a
 Ocean Fishin' is currently only availble as testing plugin. See [the FAQ](https://goatcorp.github.io/faq/dalamud_troubleshooting.html#q-how-do-i-enable-plugin-test-builds) for how to install testing plugins. 
 
 ## How to Use
-`/oceanfishing` or `/bait` to open the plugin window.
+`/oceanfishing` or `/fishin` to open the plugin window.
 
 ## Features
 While in the ocean fishing duty, this plugin suggests bait to use...


### PR DESCRIPTION
OF' has seniority using `/bait`, but ST's usage is a lot more general - it allows switching bait by name and therefore by macro, which i'd argue is a better fit.

`/fishin` seemed like a good alternative, and users not interested in Bait Command could recreate the original `/bait` functionality with ST's Command Alias.

(+ the linux dalamud path in .csproj so i could build it)